### PR TITLE
Fixed #9 Mixed charsets now supported

### DIFF
--- a/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
+++ b/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
@@ -1,5 +1,7 @@
 package org.bbottema.rtftohtml.impl.util;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
@@ -23,5 +25,51 @@ public class CharsetHelper {
 			}
 		}
 		throw new UnsupportedCharsetException(rtfCodePage);
+	}
+	
+	@Nullable
+	public static Charset rtfCharset(int rtfCharsetNumber) {
+		// RTF specific table lifted from wikipedia: https://en.wikipedia.org/wiki/Rich_Text_Format
+		switch(rtfCharsetNumber) {
+			case 0:
+				return Charset.forName("Windows-1252");
+			case 1:
+			case 2:
+			case 77:
+				// special Charsets that are not really mappable by java
+				return null;
+			case 128:
+				return Charset.forName("Windows-932");
+			case 129:
+				return Charset.forName("Windows-949");
+			case 130:
+				return Charset.forName("ms1361");
+			case 134:
+				return Charset.forName("Windows-936");
+			case 136:
+				return Charset.forName("Windows-950");
+			case 161:
+				return Charset.forName("Windows-1253");
+			case 163:
+				return Charset.forName("Windows-1254");
+			case 177:
+				return Charset.forName("Windows-1258");
+			case 178:
+				return Charset.forName("Windows-1255");
+			case 186:
+				return Charset.forName("Windows-1256");
+			case 204:
+				return Charset.forName("Windows-1257");
+			case 222:
+				return Charset.forName("Windows-1251");
+			case 238:
+				return Charset.forName("Windows-1250");
+			case 255:
+				// "Default OEM code page for system locale"
+				// This will likely not work in practise. 
+				return Charset.defaultCharset();
+			default:
+				return null;
+		}
 	}
 }

--- a/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
+++ b/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
@@ -30,6 +30,7 @@ public class CharsetHelper {
 	@Nullable
 	public static Charset rtfCharset(int rtfCharsetNumber) {
 		// RTF specific table lifted from wikipedia: https://en.wikipedia.org/wiki/Rich_Text_Format
+		// Augmented by info from here http://ftp.artifax.net/ArtRep/2.0/Help/rtf.htm
 		switch(rtfCharsetNumber) {
 			case 0:
 				return Charset.forName("Windows-1252");
@@ -50,20 +51,29 @@ public class CharsetHelper {
 				return Charset.forName("Windows-950");
 			case 161:
 				return Charset.forName("Windows-1253");
+			case 162:
+				return Charset.forName("cp857");
 			case 163:
 				return Charset.forName("Windows-1254");
-			case 177:
-				return Charset.forName("Windows-1258");
-			case 178:
+			case 177: // HEBREW_CHARSET
+			case 181: // HEBREWUSER_CHARSET
+				// Can't find different charsets for these different types of hebrew
 				return Charset.forName("Windows-1255");
+			case 178: // ARABICSIMPLIFIED_CHARSET
+			case 179: // ARABICTRADITIONAL_CHARSET
+			case 180: // ARABICUSER_CHARSET
+				// Can't find different charsets for these different types of arabic
+				return Charset.forName("Windows-1256");
 			case 186:
 				return Charset.forName("Windows-1256");
 			case 204:
-				return Charset.forName("Windows-1257");
+				return Charset.forName("ISO-8859-5");
 			case 222:
 				return Charset.forName("Windows-1251");
 			case 238:
-				return Charset.forName("Windows-1250");
+				return Charset.forName("Windows-1257");
+			case 254:
+				return Charset.forName("CP437");
 			case 255:
 				// "Default OEM code page for system locale"
 				// This will likely not work in practise. 

--- a/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
+++ b/src/main/java/org/bbottema/rtftohtml/impl/util/CharsetHelper.java
@@ -67,7 +67,7 @@ public class CharsetHelper {
 			case 186:
 				return Charset.forName("Windows-1256");
 			case 204:
-				return Charset.forName("ISO-8859-5");
+				return Charset.forName("Windows-1251");
 			case 222:
 				return Charset.forName("Windows-1251");
 			case 238:

--- a/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
+++ b/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
@@ -39,4 +39,12 @@ public class RTF2HTMLConverterRFCCompliantTest {
 
         assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
     }
+    
+    @Test
+    public void testMixedCharsets() {
+        String html = RTF2HTMLConverterRFCCompliant.INSTANCE.rtf2html(classpathFileToString("test-messages/input/mixed-charsets-test.rtf"));
+        String expectedHtml = classpathFileToString("test-messages/output/rfcompliant/mixed-charsets-test.html");
+
+        assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
+    }
 }

--- a/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
+++ b/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
@@ -47,4 +47,12 @@ public class RTF2HTMLConverterRFCCompliantTest {
 
         assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
     }
+    
+    @Test
+    public void testHebrewCharset() {
+        String html = RTF2HTMLConverterRFCCompliant.INSTANCE.rtf2html(classpathFileToString("test-messages/input/hebrew-test.rtf"));
+        String expectedHtml = classpathFileToString("test-messages/output/rfcompliant/hebrew-test.html");
+
+        assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
+    }
 }

--- a/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
+++ b/src/test/java/org/bbottema/rtftohtml/impl/RTF2HTMLConverterRFCCompliantTest.java
@@ -55,4 +55,12 @@ public class RTF2HTMLConverterRFCCompliantTest {
 
         assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
     }
+
+    @Test
+    public void testRussianCharset() {
+        String html = RTF2HTMLConverterRFCCompliant.INSTANCE.rtf2html(classpathFileToString("test-messages/input/russian-test.rtf"));
+        String expectedHtml = classpathFileToString("test-messages/output/rfcompliant/russian-test.html");
+
+        assertThat(normalizeText(html)).isEqualTo(normalizeText(expectedHtml));
+    }
 }

--- a/src/test/resources/test-messages/input/hebrew-test.rtf
+++ b/src/test/resources/test-messages/input/hebrew-test.rtf
@@ -1,0 +1,107 @@
+{\rtf1\ansi\ansicpg1255\fromhtml1 \fbidis \deff0{\fonttbl
+
+{\f0\fswiss\fcharset177 Arial;}
+
+{\f1\fmodern Courier New;}
+
+{\f2\fnil\fcharset2 Symbol;}
+
+{\f3\fmodern\fcharset0 Courier New;}
+
+{\f4\fswiss\fcharset177 "Arial";}}
+
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+
+\uc1\pard\plain\deftab360 \f0\fs24 
+
+{\*\htmltag2 \par }
+
+{\*\htmltag18 <html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">}
+
+{\*\htmltag34 <head>}
+
+{\*\htmltag161 <meta name=Generator content="Microsoft Word 15 (filtered medium)">}
+
+{\*\htmltag241 <style>}
+
+{\*\htmltag241 <!--\par /* Font Definitions */\par @font-face\par \tab \{font-family:"Cambria Math";\par \tab panose-1:2 4 5 3 5 4 6 3 2 4;\}\par @font-face\par \tab \{font-family:Calibri;\par \tab panose-1:2 15 5 2 2 2 4 3 2 4;\}\par /* Style Definitions */\par p.MsoNormal, li.MsoNormal, div.MsoNormal\par \tab \{margin:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\par \tab mso-fareast-language:EN-US;\}\par span.EmailStyle17\par \tab \{mso-style-type:personal-compose;\par \tab font-family:"Calibri",sans-serif;\par \tab color:windowtext;\}\par span.Char\par \tab \{mso-style-name:"\\666E\\901A\\(\\7F51\\7AD9\\) Char\\,\\666E\\901A \\(Web\\) Char\\,\\666E\\901A\\(Web\\) Char\\,\\666E\\901A\\(?\\7AD9\\) Char\\,\\666E\\901A\\(F51\\7AD9\\) Char\\,\\666E\\901A  Char\\,\\666E\\901A\\(_F51\\7AD9\\) Char\\,\\666E\\901A\\(\\7F51 \\7AD9\\) Char\\,\\666E\\901A\\(F51\\7AD9\\) Char\\,\\666E\\901A Char\\,\\666E\\901A\\( F51\\7AD9\\) Char\\,\\666E\\901A\\(? \\7AD9\\) Char\\,\\666E\\901A\\(?F51\\7AD9\\) Char\\,\\666E\\901AChar\\,\\666E\\901A\\(&\\#32593\\,\\7AD9\\) Char\\,\\666E\\901A\\(\\7AD9\\) Char\\,\\666E\\901A\\(\\7F51  \\7AD9\\) Char\\,\\666E\\901A\\(\\7DB2\\7AD9\\) Char\\,\\666E\\901A\\(\\7DB2 \\7AD9\\) Char";\par \tab mso-style-priority:99;\par \tab mso-style-link:wordsection1;\par \tab font-family:"Calibri",sans-serif;\}\par p.wordsection1, li.wordsection1, div.wordsection1\par \tab \{mso-style-name:wordsection1;\par \tab mso-style-priority:99;\par \tab mso-style-link:"\\666E\\901A\\(\\7F51\\7AD9\\) Char\\,\\666E\\901A \\(Web\\) Char\\,\\666E\\901A\\(Web\\) Char\\,\\666E\\901A\\(?\\7AD9\\) Char\\,\\666E\\901A\\(F51\\7AD9\\) Char\\,\\666E\\901A  Char\\,\\666E\\901A\\(_F51\\7AD9\\) Char\\,\\666E\\901A\\(\\7F51 \\7AD9\\) Char\\,\\666E\\901A\\(F51\\7AD9\\) Char\\,\\666E\\901A Char\\,\\666E\\901A\\( F51\\7AD9\\) Char\\,\\666E\\901A\\(? \\7AD9\\) Char\\,\\666E\\901A\\(?F51\\7AD9\\) Char\\,\\666E\\901AChar\\,\\666E\\901A\\(&\\#32593\\,\\7AD9\\) Char\\,\\666E\\901A\\(\\7AD9\\) Char\\,\\666E\\901A\\(\\7F51  \\7AD9\\) Char\\,\\666E\\901A\\(\\7DB2\\7AD9\\) Char\\,\\666E\\901A\\(\\7DB2 \\7AD9\\) Char";\par \tab mso-margin-top-alt:auto;\par \tab margin-right:0in;\par \tab mso-margin-bottom-alt:auto;\par \tab margin-left:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\par \tab mso-fareast-language:EN-US;\}\par .MsoChpDefault\par \tab \{mso-style-type:export-only;\par \tab font-family:"Calibri",sans-serif;\par \tab mso-fareast-language:EN-US;\}\par @page WordSection1\par \tab \{size:8.5in 11.0in;\par \tab margin:1.0in 1.0in 1.0in 1.0in;\}\par div.WordSection1\par \tab \{page:WordSection1;\}\par -->}
+
+{\*\htmltag249 </style>}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapedefaults v:ext="edit" spidmax="1026" />\par </xml><![endif]-->}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapelayout v:ext="edit">\par <o:idmap v:ext="edit" data="1" />\par </o:shapelayout></xml><![endif]-->}
+
+{\*\htmltag41 </head>}
+
+{\*\htmltag50 <body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'>}
+
+{\*\htmltag96 <div class=WordSection1>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag64 <p class=wordsection1 dir=RTL style='margin:0in;mso-add-space:auto;text-align:right;direction:rtl;unicode-bidi:embed'>}\htmlrtf {\htmlrtf0 \htmlrtf \rtlpar\rtlch\qr \htmlrtf0 
+
+{\*\htmltag84 <b>}\htmlrtf {\b \htmlrtf0 
+
+{\*\htmltag84 <u>}\htmlrtf {\ul \htmlrtf0 
+
+{\*\htmltag148 <span lang=HE style='font-size:13.5pt;font-family:"Arial",sans-serif;color:red'>}\htmlrtf {\f4 \htmlrtf0 \'ec\'fa\'f9\'e5\'ee\'fa \'ec\'e9\'e1\'ea: \'ee\'e9\'e9\'ec \'e6\'e4 \'e4\'e2\'e9\'f2 \'e0\'ec\'e9\'ea \'ee\'e2\'e5\'f8\'ed \'e7\'e9\'f6\'e5\'f0\'e9.
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag92 </u>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag92 </b>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag148 <span dir=LTR>}\htmlrtf {\ltrch \htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}\rtlch 
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=wordsection1 dir=RTL style='margin:0in;mso-add-space:auto;text-align:right;direction:rtl;unicode-bidi:embed'>}\htmlrtf {\htmlrtf0 \htmlrtf \rtlpar\rtlch\qr \htmlrtf0 
+
+{\*\htmltag148 <span lang=HE style='font-size:12.0pt;font-family:"Arial",sans-serif;color:red'>}\htmlrtf {\f4 \htmlrtf0 \'e0\'e9\'ef \'ec\'e4\'f9\'e9\'e1, \'ec\'ec\'e7\'e5\'f5 \'f2\'ec \'f7\'e9\'f9\'e5\'f8\'e9\'ed \'e0\'e5 \'ec\'f4\'fa\'e5\'e7 \'f7\'e1\'f6\'e9\'ed, \'e0\'ed \'e0\'e9\'f0\'ea \'ee\'e6\'e4\'e4 \'e1\'e5\'e5\'e3\'e0\'e5\'fa \'e0\'fa \'e4\'f9\'e5\'ec\'e7 \'e5\'ee\'f9\'e5\'eb\'f0\'f2 \'f9\'e4\'fa\'e5\'eb\'ef \'e1\'e8\'e5\'e7.
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag148 <span lang=AR-SA>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}\htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag58 </body>}
+
+{\*\htmltag27 </html>}}r\

--- a/src/test/resources/test-messages/input/mixed-charsets-test.rtf
+++ b/src/test/resources/test-messages/input/mixed-charsets-test.rtf
@@ -1,0 +1,130 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+
+{\f0\fswiss\fcharset0 Arial;}
+
+{\f1\fmodern Courier New;}
+
+{\f2\fnil\fcharset2 Symbol;}
+
+{\f3\fmodern\fcharset0 Courier New;}
+
+{\f4\fswiss\fcharset0 "Segoe UI Emoji";}
+
+{\f5\fswiss\fcharset0 "MS Mincho";}
+
+{\f6\fswiss\fcharset128 "MS Mincho";}}
+
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+
+\uc1\pard\plain\deftab360 \f0\fs24 
+
+{\*\htmltag2 \par }
+
+{\*\htmltag18 <html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">}
+
+{\*\htmltag34 <head>}
+
+{\*\htmltag161 <meta name=Generator content="Microsoft Word 15 (filtered medium)">}
+
+{\*\htmltag241 <style>}
+
+{\*\htmltag241 <!--\par /* Font Definitions */\par @font-face\par \tab \{font-family:"MS Mincho";\par \tab panose-1:2 2 6 9 4 2 5 8 3 4;\}\par @font-face\par \tab \{font-family:"Cambria Math";\par \tab panose-1:2 4 5 3 5 4 6 3 2 4;\}\par @font-face\par \tab \{font-family:Calibri;\par \tab panose-1:2 15 5 2 2 2 4 3 2 4;\}\par @font-face\par \tab \{font-family:"Segoe UI Emoji";\par \tab panose-1:2 11 5 2 4 2 4 2 2 3;\}\par @font-face\par \tab \{font-family:"\\@MS Mincho";\par \tab panose-1:2 2 6 9 4 2 5 8 3 4;\}\par /* Style Definitions */\par p.MsoNormal, li.MsoNormal, div.MsoNormal\par \tab \{margin:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\}\par span.EmailStyle17\par \tab \{mso-style-type:personal-compose;\par \tab font-family:"Calibri",sans-serif;\par \tab color:windowtext;\}\par .MsoChpDefault\par \tab \{mso-style-type:export-only;\par \tab font-family:"Calibri",sans-serif;\par \tab mso-fareast-language:EN-US;\}\par @page WordSection1\par \tab \{size:8.5in 11.0in;\par \tab margin:1.0in 1.0in 1.0in 1.0in;\}\par div.WordSection1\par \tab \{page:WordSection1;\}\par -->}
+
+{\*\htmltag249 </style>}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapedefaults v:ext="edit" spidmax="1026" />\par </xml><![endif]-->}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapelayout v:ext="edit">\par <o:idmap v:ext="edit" data="1" />\par </o:shapelayout></xml><![endif]-->}
+
+{\*\htmltag41 </head>}
+
+{\*\htmltag50 <body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'>}
+
+{\*\htmltag96 <div class=WordSection1>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US>}\htmlrtf {\htmlrtf0 Thanks for your email 
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US style='font-family:"Segoe UI Emoji",sans-serif'>}\htmlrtf {\f4 \htmlrtf0 \u-10179 ?\u-8694 ?
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span style='mso-fareast-language:EN-US'>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 Kind regards / Cordiali saluti / Freundliche Gr\'fcsse
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 /
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag148 <span style='font-family:"MS Mincho",serif'>}\htmlrtf {\f5 \htmlrtf0 \htmlrtf{\f6\fs24\htmlrtf0 \'8d\'9f\'92\'76\'8c\'68\'97\'e7\htmlrtf\f5}\htmlrtf0 
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}\htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span style='mso-fareast-language:EN-US'>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag58 </body>}
+
+{\*\htmltag27 </html>}}
+

--- a/src/test/resources/test-messages/input/russian-test.rtf
+++ b/src/test/resources/test-messages/input/russian-test.rtf
@@ -1,0 +1,165 @@
+{\rtf1\ansi\ansicpg1252\fromhtml1 \fbidis \deff0{\fonttbl
+
+{\f0\fswiss\fcharset0 Arial;}
+
+{\f1\fmodern Courier New;}
+
+{\f2\fnil\fcharset2 Symbol;}
+
+{\f3\fmodern\fcharset0 Courier New;}
+
+{\f4\fswiss\fcharset204 Arial;}
+
+{\f5\fswiss\fcharset0 "Kunstler Script";}}
+
+{\colortbl\red0\green0\blue0;\red5\green99\blue193;}
+
+\uc1\pard\plain\deftab360 \f0\fs24 
+
+{\*\htmltag19 <html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">}
+
+{\*\htmltag34 <head>}
+
+{\*\htmltag161 <meta name=Generator content="Microsoft Word 15 (filtered medium)">}
+
+{\*\htmltag241 <style>}
+
+{\*\htmltag241 <!--\par /* Font Definitions */\par @font-face\par \tab \{font-family:"Cambria Math";\par \tab panose-1:2 4 5 3 5 4 6 3 2 4;\}\par @font-face\par \tab \{font-family:Calibri;\par \tab panose-1:2 15 5 2 2 2 4 3 2 4;\}\par @font-face\par \tab \{font-family:"Kunstler Script";\par \tab panose-1:3 3 4 2 2 6 7 13 13 6;\}\par /* Style Definitions */\par p.MsoNormal, li.MsoNormal, div.MsoNormal\par \tab \{margin:0in;\par \tab font-size:11.0pt;\par \tab font-family:"Calibri",sans-serif;\}\par .MsoChpDefault\par \tab \{mso-style-type:export-only;\par \tab font-size:10.0pt;\}\par @page WordSection1\par \tab \{size:8.5in 11.0in;\par \tab margin:1.0in 1.0in 1.0in 1.0in;\}\par div.WordSection1\par \tab \{page:WordSection1;\}\par -->}
+
+{\*\htmltag249 </style>}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapedefaults v:ext="edit" spidmax="1026" />\par </xml><![endif]-->}
+
+{\*\htmltag241 <!--[if gte mso 9]><xml>\par <o:shapelayout v:ext="edit">\par <o:idmap v:ext="edit" data="1" />\par </o:shapelayout></xml><![endif]-->}
+
+{\*\htmltag41 </head>}
+
+{\*\htmltag50 <body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'>}
+
+{\*\htmltag96 <div class=WordSection1>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}\htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=RU>}\htmlrtf {\htmlrtf0 \htmlrtf{\f4\fs24\htmlrtf0 \'c4\'e0\'e2\'e0\'e9\'f2\'e5 \'e7\'e0\'e2\'f2\'f0\'e0 \'f1 \'c2\'e0\'ec\'e8 \'ed\'e0 \'fd\'f2\'f3 \'f2\'e5\'ec\'f3 \'f1\'ee\'e7\'e2\'ee\'ed\'e8\'ec\'f1\'ff.\htmlrtf\f0}\htmlrtf0  
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=RU>}\htmlrtf {\htmlrtf0 \htmlrtf{\f4\fs24\htmlrtf0 \'c8\'eb\'e8 \'ec\'ee\'e3\'f3 \'f1\'e5\'e3\'ee\'e4\'ed\'ff , \'ea\'e0\'ea \'f1\'ee \'e2\'f0\'e5\'ec\'e5\'ed\'e8\'ec ?\htmlrtf\f0}\htmlrtf0  
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=RU>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag96 <div>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US style='color:#002060'>}\htmlrtf {\htmlrtf0 Kind regards, 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US style='font-family:"Kunstler Script"'>}\htmlrtf {\f5 \htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag64 <p class=MsoNormal>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag148 <span lang=EN-US>}\htmlrtf {\htmlrtf0 
+
+{\*\htmltag244 <o:p>}
+
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 
+
+{\*\htmltag252 </o:p>}
+
+{\*\htmltag156 </span>}\htmlrtf }\htmlrtf0 \htmlrtf\par}\htmlrtf0
+
+\htmlrtf \par
+
+\htmlrtf0 
+
+{\*\htmltag72 </p>}
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+
+{\*\htmltag58 </body>}
+
+{\*\htmltag27 </html>}}-m

--- a/src/test/resources/test-messages/output/rfcompliant/hebrew-test.html
+++ b/src/test/resources/test-messages/output/rfcompliant/hebrew-test.html
@@ -1,0 +1,50 @@
+
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head><meta name=Generator content="Microsoft Word 15 (filtered medium)"><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri",sans-serif;
+	color:windowtext;}
+span.Char
+	{mso-style-name:"\666E\901A\(\7F51\7AD9\) Char\,\666E\901A \(Web\) Char\,\666E\901A\(Web\) Char\,\666E\901A\(?\7AD9\) Char\,\666E\901A\(F51\7AD9\) Char\,\666E\901A  Char\,\666E\901A\(_F51\7AD9\) Char\,\666E\901A\(\7F51 \7AD9\) Char\,\666E\901A\(F51\7AD9\) Char\,\666E\901A Char\,\666E\901A\( F51\7AD9\) Char\,\666E\901A\(? \7AD9\) Char\,\666E\901A\(?F51\7AD9\) Char\,\666E\901AChar\,\666E\901A\(&\#32593\,\7AD9\) Char\,\666E\901A\(\7AD9\) Char\,\666E\901A\(\7F51  \7AD9\) Char\,\666E\901A\(\7DB2\7AD9\) Char\,\666E\901A\(\7DB2 \7AD9\) Char";
+	mso-style-priority:99;
+	mso-style-link:wordsection1;
+	font-family:"Calibri",sans-serif;}
+p.wordsection1, li.wordsection1, div.wordsection1
+	{mso-style-name:wordsection1;
+	mso-style-priority:99;
+	mso-style-link:"\666E\901A\(\7F51\7AD9\) Char\,\666E\901A \(Web\) Char\,\666E\901A\(Web\) Char\,\666E\901A\(?\7AD9\) Char\,\666E\901A\(F51\7AD9\) Char\,\666E\901A  Char\,\666E\901A\(_F51\7AD9\) Char\,\666E\901A\(\7F51 \7AD9\) Char\,\666E\901A\(F51\7AD9\) Char\,\666E\901A Char\,\666E\901A\( F51\7AD9\) Char\,\666E\901A\(? \7AD9\) Char\,\666E\901A\(?F51\7AD9\) Char\,\666E\901AChar\,\666E\901A\(&\#32593\,\7AD9\) Char\,\666E\901A\(\7AD9\) Char\,\666E\901A\(\7F51  \7AD9\) Char\,\666E\901A\(\7DB2\7AD9\) Char\,\666E\901A\(\7DB2 \7AD9\) Char";
+	mso-margin-top-alt:auto;
+	margin-right:0in;
+	mso-margin-bottom-alt:auto;
+	margin-left:0in;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:8.5in 11.0in;
+	margin:1.0in 1.0in 1.0in 1.0in;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext="edit" spidmax="1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext="edit">
+<o:idmap v:ext="edit" data="1" />
+</o:shapelayout></xml><![endif]--></head><body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'><div class=WordSection1><p class=wordsection1 dir=RTL style='margin:0in;mso-add-space:auto;text-align:right;direction:rtl;unicode-bidi:embed'><b><u><span lang=HE style='font-size:13.5pt;font-family:"Arial",sans-serif;color:red'>לתשומת ליבך: מייל זה הגיע אליך מגורם חיצוני.</span></u></b><span dir=LTR><o:p></o:p></span></p><p class=wordsection1 dir=RTL style='margin:0in;mso-add-space:auto;text-align:right;direction:rtl;unicode-bidi:embed'><span lang=HE style='font-size:12.0pt;font-family:"Arial",sans-serif;color:red'>אין להשיב, ללחוץ על קישורים או לפתוח קבצים, אם אינך מזהה בוודאות את השולח ומשוכנע שהתוכן בטוח.</span><span lang=AR-SA><o:p></o:p></span></p><p class=MsoNormal><o:p>&nbsp;</o:p></p></div></body></html>

--- a/src/test/resources/test-messages/output/rfcompliant/mixed-charsets-test.html
+++ b/src/test/resources/test-messages/output/rfcompliant/mixed-charsets-test.html
@@ -1,0 +1,42 @@
+
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head><meta name=Generator content="Microsoft Word 15 (filtered medium)"><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"MS Mincho";
+	panose-1:2 2 6 9 4 2 5 8 3 4;}
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:"Segoe UI Emoji";
+	panose-1:2 11 5 2 4 2 4 2 2 3;}
+@font-face
+	{font-family:"\@MS Mincho";
+	panose-1:2 2 6 9 4 2 5 8 3 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri",sans-serif;
+	color:windowtext;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:8.5in 11.0in;
+	margin:1.0in 1.0in 1.0in 1.0in;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext="edit" spidmax="1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext="edit">
+<o:idmap v:ext="edit" data="1" />
+</o:shapelayout></xml><![endif]--></head><body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'><div class=WordSection1><p class=MsoNormal><span lang=EN-US>Thanks for your email </span><span lang=EN-US style='font-family:"Segoe UI Emoji",sans-serif'>😊</span><span lang=EN-US><o:p></o:p></span></p><p class=MsoNormal><span style='mso-fareast-language:EN-US'><o:p>&nbsp;</o:p></span></p><p class=MsoNormal>Kind regards / Cordiali saluti / Freundliche Grüsse&nbsp;/&nbsp;<span style='font-family:"MS Mincho",serif'>此致敬礼</span><o:p></o:p></p><p class=MsoNormal><span style='mso-fareast-language:EN-US'><o:p>&nbsp;</o:p></span></p></div></body></html>

--- a/src/test/resources/test-messages/output/rfcompliant/russian-test.html
+++ b/src/test/resources/test-messages/output/rfcompliant/russian-test.html
@@ -1,0 +1,30 @@
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head><meta name=Generator content="Microsoft Word 15 (filtered medium)"><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:"Kunstler Script";
+	panose-1:3 3 4 2 2 6 7 13 13 6;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-size:10.0pt;}
+@page WordSection1
+	{size:8.5in 11.0in;
+	margin:1.0in 1.0in 1.0in 1.0in;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext="edit" spidmax="1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext="edit">
+<o:idmap v:ext="edit" data="1" />
+</o:shapelayout></xml><![endif]--></head><body lang=DE-CH link="#0563C1" vlink="#954F72" style='word-wrap:break-word'><div class=WordSection1><p class=MsoNormal><o:p>&nbsp;</o:p></p><p class=MsoNormal><span lang=RU>Давайте завтра с Вами на эту тему созвонимся. <o:p></o:p></span></p><p class=MsoNormal><span lang=RU>Или могу сегодня , как со временим ? <o:p></o:p></span></p><p class=MsoNormal><span lang=RU><o:p>&nbsp;</o:p></span></p><div><p class=MsoNormal><span lang=EN-US style='color:#002060'>Kind regards, <o:p></o:p></span></p><p class=MsoNormal><span lang=EN-US style='font-family:"Kunstler Script"'><o:p>&nbsp;</o:p></span></p></div><p class=MsoNormal><span lang=EN-US><o:p>&nbsp;</o:p></span></p></div></body></html>


### PR DESCRIPTION
Now interpreting enough of the font table to get the charset for
each font. If we encounter a byte string we interpret these bytes
in the charset of the currently active font, or the default
charset of the document, if no font is active.